### PR TITLE
メモの保存先をJSONファイルからpostgresqlに変更した

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,7 @@ source 'https://rubygems.org'
 gem 'sinatra'
 gem 'sinatra-reloader'
 
+gem 'pg'
+
 gem 'puma'
 gem 'rackup'

--- a/README.md
+++ b/README.md
@@ -13,10 +13,17 @@ $ cd try-sinatra
 $ bundle
 ```
 
-メモを保存するための json ファイルを準備する
+環境変数に postgresql の user, password を設定してください
 
 ```sh
-$ echo '[]' > data/memos.json
+export PG_USER=XXXX
+export PG_PASSWORD=XXXX
+```
+
+DB をセットアップする。
+
+```sh
+$ rake db:create
 ```
 
 アプリを起動する
@@ -26,3 +33,11 @@ $ bundle exec ruby app.rb
 ```
 
 http://localhost:4567/ でメモアプリを表示できること
+
+## その他
+
+不要になった DB は db:drop コマンドで削除してください
+
+```sh
+$ rake db:drop
+```

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'pg'
+require 'json'
+
+def create_database
+  connection = PG.connect(dbname: 'postgres')
+  connection.exec('CREATE DATABASE memo_app')
+end
+
+def setup_tables
+  connection = PG.connect(dbname: 'memo_app')
+  connection.exec('CREATE TABLE memos (id SERIAL PRIMARY KEY, title VARCHAR(255), body TEXT)')
+  file = File.read('./data/memos_seed.json')
+  JSON.parse(file, symbolize_names: true).each do |memo|
+    connection.exec("INSERT INTO memos (title, body) VALUES ('#{memo[:title]}', '#{memo[:body]}')")
+  end
+end
+
+namespace :db do
+  task :create do
+    create_database
+    setup_tables
+  end
+
+  task :drop do
+    connection = PG.connect(dbname: 'postgres')
+    connection.exec('DROP DATABASE memo_app')
+  end
+end

--- a/Rakefile
+++ b/Rakefile
@@ -8,19 +8,15 @@ def create_database
   connection.exec('CREATE DATABASE memo_app')
 end
 
-def setup_tables
+def create_table
   connection = PG.connect(dbname: 'memo_app')
   connection.exec('CREATE TABLE memos (id SERIAL PRIMARY KEY, title VARCHAR(255), body TEXT)')
-  file = File.read('./data/memos_seed.json')
-  JSON.parse(file, symbolize_names: true).each do |memo|
-    connection.exec("INSERT INTO memos (title, body) VALUES ('#{memo[:title]}', '#{memo[:body]}')")
-  end
 end
 
 namespace :db do
   task :create do
     create_database
-    setup_tables
+    create_table
   end
 
   task :drop do

--- a/Rakefile
+++ b/Rakefile
@@ -1,17 +1,6 @@
 # frozen_string_literal: true
 
-require 'pg'
-require 'json'
-
-def create_database
-  connection = PG.connect(dbname: 'postgres')
-  connection.exec('CREATE DATABASE memo_app')
-end
-
-def create_table
-  connection = PG.connect(dbname: 'memo_app')
-  connection.exec('CREATE TABLE memos (id SERIAL PRIMARY KEY, title VARCHAR(255), body TEXT)')
-end
+require_relative 'lib/db'
 
 namespace :db do
   task :create do
@@ -20,7 +9,6 @@ namespace :db do
   end
 
   task :drop do
-    connection = PG.connect(dbname: 'postgres')
-    connection.exec('DROP DATABASE memo_app')
+    drop_database
   end
 end

--- a/lib/db.rb
+++ b/lib/db.rb
@@ -2,13 +2,16 @@
 
 require 'pg'
 
-def sql(cmd, *args)
+def setup_connection
   opts = {
     'user' => ENV['PG_USER'] || 'postgres',
     'password' => ENV['PG_PASSWORD'] || 'password',
     'dbname' => 'memo_app'
   }
+  PG::Connection.new(opts)
+end
 
-  $connection ||= PG::Connection.new(opts) # rubocop:disable Style/GlobalVars
-  $connection.exec(cmd, args) # rubocop:disable Style/GlobalVars
+def sql(cmd, *args)
+  @connection ||= setup_connection
+  @connection.exec(cmd, args)
 end

--- a/lib/db.rb
+++ b/lib/db.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'pg'
+
+def sql(cmd, *args)
+  opts = {
+    'user' => ENV['PG_USER'] || 'postgres',
+    'password' => ENV['PG_PASSWORD'] || 'password',
+    'dbname' => 'memo_app'
+  }
+
+  $connection ||= PG::Connection.new(opts) # rubocop:disable Style/GlobalVars
+  $connection.exec(cmd, args) # rubocop:disable Style/GlobalVars
+end

--- a/lib/db.rb
+++ b/lib/db.rb
@@ -2,7 +2,9 @@
 
 require 'pg'
 
-def setup_connection(dbname: 'memo_app')
+DB_NAME = 'memo_app'
+
+def setup_connection(dbname: DB_NAME)
   opts = {
     'user' => ENV['PG_USER'] || 'postgres',
     'password' => ENV['PG_PASSWORD'] || 'password',
@@ -18,7 +20,7 @@ end
 
 def create_database
   connection = setup_connection(dbname: 'postgres')
-  connection.exec('CREATE DATABASE memo_app')
+  connection.exec("CREATE DATABASE #{DB_NAME}")
 end
 
 def create_table
@@ -28,6 +30,6 @@ end
 
 def drop_database
   connection = setup_connection(dbname: 'postgres')
-  connection.exec('DROP DATABASE memo_app')
+  connection.exec("DROP DATABASE #{DB_NAME}")
 end
 

--- a/lib/db.rb
+++ b/lib/db.rb
@@ -2,11 +2,11 @@
 
 require 'pg'
 
-def setup_connection
+def setup_connection(dbname: 'memo_app')
   opts = {
     'user' => ENV['PG_USER'] || 'postgres',
     'password' => ENV['PG_PASSWORD'] || 'password',
-    'dbname' => 'memo_app'
+    'dbname' => dbname
   }
   PG::Connection.new(opts)
 end
@@ -15,3 +15,19 @@ def sql(cmd, *args)
   @connection ||= setup_connection
   @connection.exec(cmd, args)
 end
+
+def create_database
+  connection = setup_connection(dbname: 'postgres')
+  connection.exec('CREATE DATABASE memo_app')
+end
+
+def create_table
+  connection = setup_connection
+  connection.exec('CREATE TABLE memos (id SERIAL PRIMARY KEY, title VARCHAR(255), body TEXT)')
+end
+
+def drop_database
+  connection = setup_connection(dbname: 'postgres')
+  connection.exec('DROP DATABASE memo_app')
+end
+


### PR DESCRIPTION
## 背景
- プラクティス「WebアプリからのDB利用」として、JSONファイルに保存していたメモデータをDBに保存するよう変更したい
- DBは PostgreSQLを使う

## やったこと
- [x] PostgreSQLに接続できるようにした
- [x] Memoモデルのメモ取得、保存処理でDBを利用するよう変更した
- [x] DBの作成、削除がコマンドラインでできるようRakefileを追加した
- [x] READMEの手順を更新した
